### PR TITLE
Admin panel improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ bower.json
 ref_*
 public/jobs/*
 public/assets/*
+
+work
+*DB.org

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -39,6 +39,7 @@ class JobsController < ApplicationController
                         :started_at => job[:started_at],
                         :finished_at => job[:finished_at],
                         :name => jobname,
+                        :email => job[:email],
                         :queued => Sidekiq::Status::queued?(job[:job_id]),
                         :working => Sidekiq::Status::working?(job[:job_id]),
                         :failed => Sidekiq::Status::failed?(job[:job_id]),

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -82,6 +82,10 @@ class JobsController < ApplicationController
       flash[:info] = "You do not have permission to delete jobs in the " + \
                      "queue."
       redirect_to :welcome
+    elsif CONFIG['example_job_id'] == params[:id] then
+      flash[:info] = "Can't delete the example job. Remove the job from " + \
+                      "the configuration to allow deletion."
+      redirect_to :jobs
     else
       thisjob = Job.find_by(:job_id => params[:id])
       if thisjob then

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -12,6 +12,7 @@
             <tr>
                 <th>Name</th>
                 <th>submitted</th>
+                <th>by (email)</th>
                 <th>started</th>
                 <th>finished</th>
                 <th></th>
@@ -20,9 +21,10 @@
         </thead>
         <tbody>
 <% @outjobs.each do |job| %>
-            <tr  >
+            <tr>
                 <td width="100%"><span title="<%= job[:job_id] %>"><%= job[:name] %></span></td>
                 <td><%= distance_of_time_in_words(Time.now,job[:created_at]) %> ago</td>
+                <td><%= job[:email] %></td>
                 <td>
                   <% if job[:started_at] then %>
                     <%= distance_of_time_in_words(Time.now,job[:started_at]) %> ago

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -40,11 +40,15 @@
                 <td>
                    <div class="btn-group">
                    <% if job[:job_id] then %>
-                     <%= link_to job_path(id: job[:job_id]),
-                                        method: :delete,
-                                        data: { confirm: "Are you sure?" } do %>
-                       <i class="glyphicon glyphicon-trash"></i> Delete
-                     <% end %>&nbsp;
+                     <% if not (CONFIG['example_job_id'] == job[:job_id]) then %>
+                       <%= link_to job_path(id: job[:job_id]),
+                                            method: :delete,
+                                            data: { confirm: "Are you sure?" } do %>
+                         <i class="glyphicon glyphicon-trash"></i> Delete
+                       <% end %>&nbsp;
+                     <% else %>
+                       <span class="text-warning">(Example)</span>
+                     <% end %>
                      <%= link_to job_path(id: job[:job_id]) do %>
                        <i class="glyphicon glyphicon-eye-open"></i> Results
                      <% end %>
@@ -55,7 +59,3 @@
 <% end %>
         </tbody>
     </table>
-
-  <%= button_to new_job_path, class: "btn btn-default", method: :get do %>
-         <i class="glyphicon glyphicon-plus"></i> New job
-  <% end %>


### PR DESCRIPTION
After inadvertently deleting the example job meant to be displayed on the help pages, I made a modification to disallow example job deletion until their example status is manually cleared in the config file.
Also, the submitter's email (if available) is now shown in the admin panel. This is useful to contact submitters of failed jobs once the underlying issue is fixed.