### PR TITLE
disable job submission when work space is low

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,6 @@ gem "recaptcha", :require => "recaptcha/rails"
 
 # for efficient on-the-fly zipping
 gem "rubyzip", :require => 'zip'
+
+# for gathering filesystem information
+gem "sys-filesystem", :require => 'sys/filesystem'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.8)
     execjs (2.6.0)
+    ffi (1.9.10)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -160,6 +161,8 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.11)
+    sys-filesystem (1.1.5)
+      ffi
     thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -203,5 +206,6 @@ DEPENDENCIES
   sidekiq-status
   spring (= 1.2.0)
   sqlite3
+  sys-filesystem
   thin
   uglifier (>= 2.7.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,13 @@
+MEGABYTE = 1024.0 * 1024.0
+
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   include SessionsHelper
+  include Sys
 
-  before_filter :number_of_jobs
+  before_filter :number_of_jobs, :check_diskspace
 
   def number_of_jobs
     @n_working = 0
@@ -18,6 +21,19 @@ class ApplicationController < ActionController::Base
                 @n_working = @n_working + 1
             end
         end
+    end
+  end
+
+  def check_diskspace
+    if not CONFIG['min_work_space'] then
+      @space_low = false
+    else
+      stat = Filesystem.stat(CONFIG['workdir'])
+      if ((stat.block_size*stat.blocks_available) / MEGABYTE) < CONFIG['min_work_space'].to_i then
+        @space_low = true
+      else
+        @space_low = false
+      end
     end
   end
 end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,20 +1,26 @@
 class JobsController < ApplicationController
   def new
-    # set defaults
-    @job = Job.new
-    @job[:do_contiguate] = true
-    @job[:do_exonerate] = false
-    @job[:do_ratt] = true
-    @job[:do_pseudo] = true
-    @job[:use_transcriptome_data] = false
-    @job[:no_resume] = false
-    @job[:max_gene_length] = 20000
-    @job[:augustus_score_threshold] = 0.8
-    @job[:taxon_id] = 5653
-    @job[:db_id] = "Companion"
-    @job[:ratt_transfer_type] = 'Species'
-    @job.build_sequence_file
-    @job.build_transcript_file
+    if @space_low then
+      flash[:info] = "New job creation is temporarily closed for technical " + \
+                     "reasons."
+      redirect_to :welcome
+    else
+      # set defaults
+      @job = Job.new
+      @job[:do_contiguate] = true
+      @job[:do_exonerate] = false
+      @job[:do_ratt] = true
+      @job[:do_pseudo] = true
+      @job[:use_transcriptome_data] = false
+      @job[:no_resume] = false
+      @job[:max_gene_length] = 20000
+      @job[:augustus_score_threshold] = 0.8
+      @job[:taxon_id] = 5653
+      @job[:db_id] = "Companion"
+      @job[:ratt_transfer_type] = 'Species'
+      @job.build_sequence_file
+      @job.build_transcript_file
+    end
   end
 
   def index

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,9 +30,9 @@
 
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
         <ul class="nav navbar-nav">
-          <li class="<%= 'active' if current_page?(new_job_path) %>">
-           <%= link_to new_job_path do  %>
-           <span class="glyphicon glyphicon-cloud-upload"></span> Submit job
+          <li class="<%= 'active' if current_page?(new_job_path) %> <%= 'disabled' if @space_low %>">
+           <%= link_to (@space_low ? '#' : new_job_path) do  %>
+             <span class="glyphicon glyphicon-cloud-upload"></span> Submit job
            <% end %>
          </li>
          <li class="<%= 'active' if current_page?(getting_started_path) %>">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,8 +4,12 @@
   <div class="row">
     <%= form_tag(:job_find, method: "get", class: "form-inline") do %>
       <div class="form-group">
-        <a class="btn btn-lg btn-primary" href="/jobs/new" role="button">Annotate <i>your</i> sequence!</a><br /><br />
-         or find your job by ID:<br /><br />
+        <% if not @space_low then %>
+          <a class="btn btn-lg btn-primary" href="/jobs/new" role="button">Annotate <i>your</i> sequence!</a> <br /><br /> or find
+        <% else %>
+          <a class="btn btn-lg btn-danger disabled" href="#" role="button">New job submission is temporarily closed for technical reasons.<br />Please try again later.</a> <br /><br /> Find
+        <% end %>
+        your job by ID:<br /><br />
         <%= text_field_tag(:id, nil, :class => "form-control input-lg", :style => "width: 350px",
                            :placeholder => "e.g. 9b0a42358d208bb061cbf2d3" ) %>
       </div>


### PR DESCRIPTION
To prevent jobs from failing, we want to keep users from submitting new jobs when the filesystem housing the work directory is almost full. The minimum amount of free space is defined in the Companion config file (will use 500MB on the current server).