### PR TITLE
adjust robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,4 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-Agent: *
+Allow: /
+Disallow: /login/
+Disallow: /jobs/


### PR DESCRIPTION
This adds a small robots.txt only hiding the admin login form, which isn't publicly linked anyway, and result pages (in case someone posts their results URL somewhere on the web).
Most of the regular content is heavily cached to a degree that it could even be considered static. The only action triggering computations (POSTed to /jobs) is reCAPTCHA-protected anyway.