### PR TITLE
Addressing user requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,6 @@ gem "rubyzip", :require => 'zip'
 
 # for gathering filesystem information
 gem "sys-filesystem", :require => 'sys/filesystem'
+
+# sitemap handling
+gem 'sitemap_generator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,8 @@ GEM
       sidekiq (>= 4)
     sidekiq-status (0.5.4)
       sidekiq (>= 2.7)
+    sitemap_generator (5.1.0)
+      builder
     spring (1.2.0)
     sprockets (3.4.1)
       rack (> 1, < 3)
@@ -204,6 +206,7 @@ DEPENDENCIES
   sidekiq (>= 3.4.0)
   sidekiq-limit_fetch
   sidekiq-status
+  sitemap_generator
   spring (= 1.2.0)
   sqlite3
   sys-filesystem

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   include SessionsHelper
   include Sys
 
-  before_filter :number_of_jobs, :check_diskspace
+  before_filter :number_of_jobs, :check_closed
 
   def number_of_jobs
     @n_working = 0
@@ -24,15 +24,19 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def check_diskspace
+  def check_closed
+    if File.exist?(Rails.root.join('CLOSED')) then
+      @closed = true
+      return
+    end
     if not CONFIG['min_work_space'] then
-      @space_low = false
+      @closed = false
     else
       stat = Filesystem.stat(CONFIG['workdir'])
       if ((stat.block_size*stat.blocks_available) / MEGABYTE) < CONFIG['min_work_space'].to_i then
-        @space_low = true
+        @closed = true
       else
-        @space_low = false
+        @closed = false
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,10 +32,14 @@ class ApplicationController < ActionController::Base
     if not CONFIG['min_work_space'] then
       @closed = false
     else
-      stat = Filesystem.stat(CONFIG['workdir'])
-      if ((stat.block_size*stat.blocks_available) / MEGABYTE) < CONFIG['min_work_space'].to_i then
-        @closed = true
-      else
+      begin
+        stat = Filesystem.stat(CONFIG['workdir'])
+        if ((stat.block_size*stat.blocks_available) / MEGABYTE) < CONFIG['min_work_space'].to_i then
+          @closed = true
+        else
+          @closed = false
+        end
+      rescue
         @closed = false
       end
     end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -154,7 +154,7 @@ class JobsController < ApplicationController
       @ref = Reference.find(@job[:reference_id])
       if @job_hash[:failed] then
         render 'jobs/show_failed'
-      elsif !@job.genome_stat or @job.genome_stat[:nof_genes] == 0 then
+      elsif @job_hash[:complete] and (!@job.genome_stat or @job.genome_stat[:nof_genes] == 0) then
         render 'jobs/show_empty'
       else
         render 'jobs/show'

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -154,6 +154,8 @@ class JobsController < ApplicationController
       @ref = Reference.find(@job[:reference_id])
       if @job_hash[:failed] then
         render 'jobs/show_failed'
+      elsif !@job.genome_stat or @job.genome_stat[:nof_genes] == 0 then
+        render 'jobs/show_empty'
       else
         render 'jobs/show'
       end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -323,7 +323,7 @@ class JobsController < ApplicationController
     params.require(:job).permit(:name, :sequence_file, :transcript_file_id, \
                                 :reference_id, :prefix, :do_pseudo, \
                                 :do_contiguate, :do_exonerate, :do_ratt, \
-                                :use_transcriptome_data, \
+                                :use_transcriptome_data, :organism, \
                                 :max_gene_length, :augustus_score_threshold , \
                                 :taxon_id, :db_id, :ratt_transfer_type, \
                                 :no_resume, :email, sequence_file_attributes: [:id, :file],

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,6 +1,6 @@
 class JobsController < ApplicationController
   def new
-    if @space_low then
+    if @closed then
       flash[:info] = "New job creation is temporarily closed for technical " + \
                      "reasons."
       redirect_to :welcome

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -119,6 +119,8 @@ module JobsHelper
       add_item("RATT_TRANSFER_TYPE", job[:ratt_transfer_type])
       add_item("MAX_GENE_LENGTH", job[:max_gene_length])
       add_item("AUGUSTUS_GENEMODEL", 'partial')
+      add_item("EMBL_ORGANISM", job[:organism])
+      add_item("embl_ena_submission", 'true')
       add_item("SPECK_TEMPLATE", "#{CONFIG['rootdir']}/data/speck/companion_html")
       add_item("AUGUSTUS_SCORE_THRESHOLD", job[:augustus_score_threshold].round(2))
       add_item("TAXON_ID", job[:taxon_id])

--- a/app/mailers/job_mailer.rb
+++ b/app/mailers/job_mailer.rb
@@ -10,6 +10,7 @@ class JobMailer < ApplicationMailer
   def finish_success_job_email(job)
     @url = jobs_url(:only_path => :true)
     @job = job
+    @ref = Reference.find(job[:reference_id])
     mail(to: @job.email, subject: "Your job '#{job[:name]}' has finished successfully")
   end
 

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -55,9 +55,9 @@ class Reference < ActiveFile::Base
   end
 
   def name_with_genes
-    out = "#{self[:name]} (#{self[:nof_genes]} genes"
+    out = "#{self[:name]} (#{self[:nof_genes]} #{"gene".pluralize(self[:nof_genes].to_i)}"
     if self.has_chromosomes? then
-      out = out + ", #{self[:nof_chromosomes]} chromosomes"
+      out = out + ", #{self[:nof_chromosomes]} #{"chromosome".pluralize(self[:nof_chromosomes].to_i)}"
     end
     out = out + ")"
   end

--- a/app/views/job_mailer/finish_success_job_email.html.erb
+++ b/app/views/job_mailer/finish_success_job_email.html.erb
@@ -8,9 +8,19 @@
     <p>
       Dear Companion user, your job "<%= @job[:name] %>" has just finished successfully!<br />
     </p>
+    <% if (!@job.genome_stat) or  @job.genome_stat[:nof_genes] == 0 then %>
+    <p>
+      Unfortunately, no genes could be annotated in the sequence you submitted.
+      This could be a result of input sequences that are too short to perform
+      reasonable gene finding. Another possible reason could be high divergence
+      of your species from the selected reference (<%= @ref[:name] %>).
+      It might probably help picking a different reference.
+    </p>
+    <% else %>
     <p>
       To inspect your <%= @job.genome_stat[:nof_genes] %> genes just follow <%= link_to "this link", job_url(id: @job[:job_id]) %>.
     </p>
+    <% end %>
     <p>Thanks for using Companion and have a nice day!</p>
   </body>
 </html>

--- a/app/views/jobs/_tabs.html.erb
+++ b/app/views/jobs/_tabs.html.erb
@@ -138,6 +138,9 @@ var vtable;
           <% end %>
         </tbody>
       </table>
+      <p>All files are provided in the following formats: GFF3 (<a href="http://www.sequenceontology.org/gff3.shtml">format specification</a>), FASTA (<a href="http://blast.ncbi.nlm.nih.gov/blastcgihelp.shtml">format specification</a>), EMBL (<a href="http://www.insdc.org/files/feature_table.html">format specification</a>), GAF 1.0 (<a href="http://geneontology.org/page/go-annotation-file-gaf-format-10">format specification</a>) and AGP 2.0 (<a href="https://www.ncbi.nlm.nih.gov/assembly/agp/AGP_Specification/">format specification</a>).
+
+      </p>
     </div>
   <% end %>
 

--- a/app/views/jobs/new.html.erb
+++ b/app/views/jobs/new.html.erb
@@ -11,19 +11,32 @@
     <h3 class="panel-title">Step 1: Basic job properties</h3>
   </div>
   <div class="panel-body">
-    <div><p>First of all, please specify a free-text <b>name</b> for your new job. It should reflect the purpose of your job, and should probably include the name of the organism you are annotating.</p></div>
+    <div>
+      <p>First of all, please specify a free-text <b>name</b> for your new job. It should reflect the purpose of your job, and should probably include the organism you are annotating.</p>
+      <p> Example: <i>My new species annotation</i></p>
+    </div>
     <div class="input-group">
-     <span class="input-group-addon" id="sizing-addon1">Job name</span>
-     <%= f.text_field :name, class: 'form-control', :aria => {:describedby => "sizing-addon1"}, required: true %>
-   </div>
-   <div style="padding-top: 20px;"><p> Please also give a short <b>species prefix</b> that will be used to name entities (such as genes, pseudochromosomes, etc.) generated during the annotation run. It should not contain spaces or special characters.</p>
-     <p> Example: <i>LFOO</i></p></div>
-     <div class="input-group">
-       <span class="input-group-addon" id="sizing-addon2">Species prefix</span>
-       <%= f.text_field :prefix, class: 'form-control', :placeholder => "LFOO", :aria => {:describedby => "sizing-addon2"}, required: true %>
-     </div>
-   </div>
- </div>
+      <span class="input-group-addon" id="sizing-addon1">Job name</span>
+      <%= f.text_field :name, class: 'form-control', :aria => {:describedby => "sizing-addon1"}, required: true %>
+    </div>
+    <div style="padding-top: 20px;">
+      <p>Please also give a short <b>species prefix</b> that will be used to name entities (such as genes, pseudochromosomes, etc.) generated during the annotation run. It should not contain spaces or special characters.</p>
+      <p> Example: <i>LDON</i></p>
+    </div>
+    <div class="input-group">
+      <span class="input-group-addon" id="sizing-addon2">Species prefix</span>
+      <%= f.text_field :prefix, class: 'form-control', :placeholder => "LFOO", :aria => {:describedby => "sizing-addon2"}, required: true %>
+    </div>
+    <div style="padding-top: 20px;">
+      <p>Finally, please provide a <b>species name</b> that describes the target species you are annotating.</p>
+      <p> Example: <i>Leishmania donovani</i></p>
+    </div>
+    <div class="input-group">
+      <span class="input-group-addon" id="sizing-addon2">Species name</span>
+      <%= f.text_field :organism, class: 'form-control', :placeholder => "Leishmania donovani", :aria => {:describedby => "sizing-addon2"}, required: true %>
+    </div>
+  </div>
+</div>
 
  <div class="panel panel-default">
   <div class="panel-heading">

--- a/app/views/jobs/show_empty.html.erb
+++ b/app/views/jobs/show_empty.html.erb
@@ -1,0 +1,27 @@
+<% content_for(:title, "#{@job[:name]} results") %>
+<div class="page-header">
+  <h1><%= @job[:name] %> <span class="small">(<%= @job[:prefix] %>)</span>
+    <%= render partial: "badge", locals: {:job => @job_hash, :extraclass => "pull-right"} %>
+  </h1>
+</div>
+
+<p>This job was submitted <b><%= distance_of_time_in_words(Time.now, @job[:created_at]) %></b> ago
+  <% if @job_hash[:complete] then %>
+    and ran for <b><%= distance_of_time_in_words(@job[:started_at], @job[:finished_at])%></b>, finally finishing at <b><%= @job[:finished_at] %></b>.
+  <% elsif @job_hash[:working] then %>
+    and is running now<% if @job[:started_at] then %>
+      for <b><%= distance_of_time_in_words(Time.now, @job[:started_at]) %></b><% end %>.
+  <% elsif @job_hash[:failed] then %>
+    and failed <b><%= distance_of_time_in_words(Time.now, @job[:finished_at]) %></b> ago.
+  <% else %>
+    and has not started yet.
+  <% end %>
+</p>
+
+<p>
+Unfortunately, no features could be annotated in the sequence you submitted.
+This could be a result of input sequences that are too short to perform
+reasonable gene finding. Another possible reason could be high divergence
+of your species from the selected reference (<i><%= @ref[:name] %></i>).
+It might probably help picking a different reference.
+</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,8 +30,8 @@
 
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
         <ul class="nav navbar-nav">
-          <li class="<%= 'active' if current_page?(new_job_path) %> <%= 'disabled' if @space_low %>">
-           <%= link_to (@space_low ? '#' : new_job_path) do  %>
+          <li class="<%= 'active' if current_page?(new_job_path) %> <%= 'disabled' if @closed %>">
+           <%= link_to (@closed ? '#' : new_job_path) do  %>
              <span class="glyphicon glyphicon-cloud-upload"></span> Submit job
            <% end %>
          </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,10 +21,10 @@
           <span class="icon-bar"></span>
         </button>
         <a href="http://www.sanger.ac.uk" class="navbar-brand">
-          <%= image_tag 'sang_logo.png' %>
+          <%= image_tag 'sang_logo.png', alt: 'Wellcome Trust Sanger Institute' %>
         </a>
         <%= link_to root_url, :class => "navbar-brand" do %>
-        <%= image_tag 'companion_logo.png' %>
+        <%= image_tag 'companion_logo.png', alt: 'Companion' %>
         <% end %>
       </div>
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,7 +4,7 @@
   <div class="row">
     <%= form_tag(:job_find, method: "get", class: "form-inline") do %>
       <div class="form-group">
-        <% if not @space_low then %>
+        <% if not @closed then %>
           <a class="btn btn-lg btn-primary" href="/jobs/new" role="button">Annotate <i>your</i> sequence!</a> <br /><br /> or find
         <% else %>
           <a class="btn btn-lg btn-danger disabled" href="#" role="button">New job submission is temporarily closed for technical reasons.<br />Please try again later.</a> <br /><br /> Find

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,5 +1,5 @@
 <div class="jumbotron">
-  <%= image_tag 'companion_logo.png' %>
+  <%= image_tag 'companion_logo.png', alt: 'Companion' %>
   <p class="lead">Easy and reliable parasite genome annotation.</p>
   <div class="row">
     <%= form_tag(:job_find, method: "get", class: "form-inline") do %>
@@ -53,7 +53,7 @@
        your compute cluster? Get <a href="http://www.nextflow.io">Nextflow</a>,
        the pipeline <a href="https://github.com/sanger-pathogens/companion">code</a>
        under the hood and the <a href="https://www.docker.com">Docker</a>
-       <a href="https://registry.hub.docker.com/u/satta/annot-nf">dependencies</a>
+       <a href="https://hub.docker.com/r/satta/companion/">dependencies</a>
        and run the whole workflow on your own machine!</p>
   </div>
 </div>

--- a/app/workers/hard_worker.rb
+++ b/app/workers/hard_worker.rb
@@ -125,115 +125,124 @@ class HardWorker
       job[:stdout] = my_stdout
       job.save!
 
-      # zip up EMBL files
-      Kernel.system("cd #{job.job_directory}; tar -czf #{job.job_directory}/embl.tar.gz *.embl")
-      if File.exist?("#{job.job_directory}/embl.tar.gz") then
-        Kernel.system("rm -f #{job.job_directory}/*.embl")
-      end
-
-      add_result_file(job, "pseudochr.fasta.gz")
-      add_result_file(job, "pseudo.out.gff3")
-      add_result_file(job, "pseudo.pseudochr.agp")
-      add_result_file(job, "scafs.fasta.gz")
-      add_result_file(job, "scaffold.out.gff3")
-      add_result_file(job, "pseudo.scafs.agp")
-      add_result_file(job, "embl.tar.gz") if File.exist?("#{job.job_directory}/embl.tar.gz")
-      add_result_file(job, "out.gaf")
-      add_result_file(job, "proteins.fasta")
-      job.save!
-
-      if (not status) or status.exitstatus != 0 then
-        raise "run failed at nextflow stage"
-      end
-
-      # stats gathering
-      if File.exist?("#{job.job_directory}/stats.txt") then
+      # job finished successfully but no annotations were created
+      if status == 0 and !File.exist?("#{job.job_directory}/pseudo.out.gff3") then
         gstat = GenomeStat.new
-        File.open("#{job.job_directory}/stats.txt").read.each_line do |l|
-          l.chomp!
-          m = /^([^:]+):\s+(.+)$/.match(l)
-          if m and gstat.has_attribute?(m[1].to_sym)
-            gstat[m[1].to_sym] = m[2]
-          end
-        end
+        gstat[:nof_genes] = 0
         gstat.save!
         job.genome_stat = gstat
         job.save!
-      end
-
-      # store circos images
-      Dir.glob("#{job.job_directory}/chr*.png") do |f|
-        m = f.match(/chr(.+)\.png$/)
-        if not m.nil? then
-          chrname = m[1]
-        else
-          chrname = "unnamed chromosome"
+      else
+        # zip up EMBL files
+        Kernel.system("cd #{job.job_directory}; tar -czf #{job.job_directory}/embl.tar.gz *.embl")
+        if File.exist?("#{job.job_directory}/embl.tar.gz") then
+          Kernel.system("rm -f #{job.job_directory}/*.embl")
         end
-        img = CircosImage.new
-        img.file = File.new(f)
-        img.chromosome = chrname
-        img.save!
-        job.circos_images << img
-        File.unlink(f)
-      end
 
-      # import genes
-      if File.exist?("#{job.job_directory}/genelist.csv") then
-        genes = []
-        File.open("#{job.job_directory}/genelist.csv").read.each_line do |l|
-          l.chomp!
-          id, type, product, seqid, start, stop, strand = l.split("\t")
-          g = Gene.new(:gene_id => id, :product => product, :loc_start => start,
-                       :loc_end => stop, :strand => strand, :job => job,
-                       :seqid => seqid, :gtype => type, :species => job[:prefix],
-                       :section => r[:section])
-          genes << g
+        add_result_file(job, "pseudochr.fasta.gz")
+        add_result_file(job, "pseudo.out.gff3")
+        add_result_file(job, "pseudo.pseudochr.agp")
+        add_result_file(job, "scafs.fasta.gz")
+        add_result_file(job, "scaffold.out.gff3")
+        add_result_file(job, "pseudo.scafs.agp")
+        add_result_file(job, "embl.tar.gz") if File.exist?("#{job.job_directory}/embl.tar.gz")
+        add_result_file(job, "out.gaf")
+        add_result_file(job, "proteins.fasta")
+        job.save!
+
+        if (not status) or status.exitstatus != 0 then
+          raise "run failed at nextflow stage"
         end
-        Gene.import(genes)
-      end
 
-      # import clusters
-      if File.exist?("#{job.job_directory}/orthomcl_out") then
-        clusters = []
-        File.open("#{job.job_directory}/orthomcl_out").each_line do |l|
-          m = l.match(/^(ORTHOMCL[0-9]+)[^:]+:\s+(.+)/)
-          next unless m
-          c = Cluster.new(:cluster_id => m[1], :job => job)
-          r = m[2].scan(/([^ ()]+)\([^)]+\)/)
-          r.each do |memb|
-            # HACK! needs to be done correctly for all possible transcript namings!
-            memb_id = memb[0].gsub(/(:.+$|\.\d+$|\.mRNA$)/,"")
-            g = Gene.where(["gene_id LIKE ? AND (job_id = #{job[:id]} OR job_id IS NULL)", "#{memb_id}%"]).take
-            if g then
-              c.genes << g
-            else
-              Rails.logger.info("#{memb[0]}: #{memb_id} (with job ID #{job[:id]}) not found!")
+        # stats gathering
+        if File.exist?("#{job.job_directory}/stats.txt") then
+          gstat = GenomeStat.new
+          File.open("#{job.job_directory}/stats.txt").read.each_line do |l|
+            l.chomp!
+            m = /^([^:]+):\s+(.+)$/.match(l)
+            if m and gstat.has_attribute?(m[1].to_sym)
+              gstat[m[1].to_sym] = m[2]
             end
           end
-          c.save!
+          gstat.save!
+          job.genome_stat = gstat
+          job.save!
         end
-      end
 
-      # store tree files
-      if File.exist?("#{job.job_directory}/tree_selection.genes") and
-        File.exist?("#{job.job_directory}/tree.aln") then
-        genes = []
-        t = Tree.new(job: job)
-        t.seq = File.new("#{job.job_directory}/tree.aln")
-        t.save!
-        File.open("#{job.job_directory}/tree_selection.genes").each_line do |l|
-          l.chomp!
-          l.split(/\s+/).each do |memb|
-            # HACK! needs to be done correctly for all possible transcript namings!
-            memb_id = memb.gsub(/(:[^:]+$|\.\d+$)/,"")
-            g = Gene.where(["gene_id LIKE ? AND (job_id = #{job[:id]} OR job_id IS NULL)", "#{memb_id}%"]).take
-            if g then
-              t.genes << g
-            else
-              Rails.logger.info("#{memb}: #{memb_id} (with job ID #{job[:id]}) not found!")
-            end
+        # store circos images
+        Dir.glob("#{job.job_directory}/chr*.png") do |f|
+          m = f.match(/chr(.+)\.png$/)
+          if not m.nil? then
+            chrname = m[1]
+          else
+            chrname = "unnamed chromosome"
           end
+          img = CircosImage.new
+          img.file = File.new(f)
+          img.chromosome = chrname
+          img.save!
+          job.circos_images << img
+          File.unlink(f)
+        end
+
+        # import genes
+        if File.exist?("#{job.job_directory}/genelist.csv") then
+          genes = []
+          File.open("#{job.job_directory}/genelist.csv").read.each_line do |l|
+            l.chomp!
+            id, type, product, seqid, start, stop, strand = l.split("\t")
+            g = Gene.new(:gene_id => id, :product => product, :loc_start => start,
+                         :loc_end => stop, :strand => strand, :job => job,
+                         :seqid => seqid, :gtype => type, :species => job[:prefix],
+                         :section => r[:section])
+            genes << g
+          end
+          Gene.import(genes)
+        end
+
+        # import clusters
+        if File.exist?("#{job.job_directory}/orthomcl_out") then
+          clusters = []
+          File.open("#{job.job_directory}/orthomcl_out").each_line do |l|
+            m = l.match(/^(ORTHOMCL[0-9]+)[^:]+:\s+(.+)/)
+            next unless m
+            c = Cluster.new(:cluster_id => m[1], :job => job)
+            r = m[2].scan(/([^ ()]+)\([^)]+\)/)
+            r.each do |memb|
+              # HACK! needs to be done correctly for all possible transcript namings!
+              memb_id = memb[0].gsub(/(:.+$|\.\d+$|\.mRNA$)/,"")
+              g = Gene.where(["gene_id LIKE ? AND (job_id = #{job[:id]} OR job_id IS NULL)", "#{memb_id}%"]).take
+              if g then
+                c.genes << g
+              else
+                Rails.logger.info("#{memb[0]}: #{memb_id} (with job ID #{job[:id]}) not found!")
+              end
+            end
+            c.save!
+          end
+        end
+
+        # store tree files
+        if File.exist?("#{job.job_directory}/tree_selection.genes") and
+          File.exist?("#{job.job_directory}/tree.aln") then
+          genes = []
+          t = Tree.new(job: job)
+          t.seq = File.new("#{job.job_directory}/tree.aln")
           t.save!
+          File.open("#{job.job_directory}/tree_selection.genes").each_line do |l|
+            l.chomp!
+            l.split(/\s+/).each do |memb|
+              # HACK! needs to be done correctly for all possible transcript namings!
+              memb_id = memb.gsub(/(:[^:]+$|\.\d+$)/,"")
+              g = Gene.where(["gene_id LIKE ? AND (job_id = #{job[:id]} OR job_id IS NULL)", "#{memb_id}%"]).take
+              if g then
+                t.genes << g
+              else
+                Rails.logger.info("#{memb}: #{memb_id} (with job ID #{job[:id]}) not found!")
+              end
+            end
+            t.save!
+          end
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,10 +12,6 @@ Rails.application.routes.draw do
   get 'welcome/run' => 'welcome#run'
   get 'welcome/clear' => 'welcome#clear'
 
-  # sign up
-  # get 'signup' => 'users#new'
-  # resources :users
-
   # jobs
   resources :jobs
   post 'jobs/new_sequence_file' => 'sequence_files#create_for_jobform'
@@ -33,10 +29,8 @@ Rails.application.routes.draw do
   get 'jobs/:id/plots.zip' => 'jobs#get_all_synteny_images', as: :all_synteny_images
 
   # uploaded files
-  get 'user_files/index'
   get 'user_files/new'
   get 'user_files/create'
-  get 'user_files/destroy'
   resources :user_files
 
   # session management
@@ -44,49 +38,4 @@ Rails.application.routes.draw do
   post   'login'   => 'sessions#create'
   delete 'logout'  => 'sessions#destroy'
 
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
 end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,0 +1,6 @@
+SitemapGenerator::Sitemap.default_host = 'https://companion.sanger.ac.uk'
+SitemapGenerator::Sitemap.create do
+  add faq_path, :priority => 0.7
+  add examples_path, :priority => 0.7
+  add getting_started_path, :priority => 0.7
+end

--- a/db/migrate/20160118160228_add_organism_to_jobs.rb
+++ b/db/migrate/20160118160228_add_organism_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddOrganismToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :organism, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151116132845) do
+ActiveRecord::Schema.define(version: 20160118160228) do
 
   create_table "circos_images", force: :cascade do |t|
     t.string   "file_uid"
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 20151116132845) do
     t.boolean  "use_transcriptome_data"
     t.boolean  "do_pseudo"
     t.string   "email"
+    t.string   "organism"
   end
 
   create_table "result_files", force: :cascade do |t|


### PR DESCRIPTION
This PR deals with issues encountered during the beta testing phase since Christmas.
- proper handling of empty annotations (e.g. when uploading 1-2kb sequences with no genes)
- improvement of Google indexing support:  sitemaps, alt tags, ...
- Pluralization nitpicks
- removal of user-facing URL routes requiring logins except for the main admin login
- User can now provide an organism string to be passed through to the EMBL export, previously default was used
- Result file formats now explained on the download page (#14).

I have also added a way to manually close the pipeline for new submissions (useful for deploying new code quickly without having to cancel running user jobs)