### PR TITLE
various improvements

### DIFF
--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -143,6 +143,8 @@ module JobsHelper
       add_item("AUGUSTUS_GENEMODEL", 'partial')
       add_item("EMBL_ORGANISM", job[:organism])
       add_item("embl_ena_submission", 'true')
+      add_item("truncate_input_headers", 'true')
+      add_item("alphanumeric_ids", 'false')
       add_item("SPECK_TEMPLATE", "#{CONFIG['rootdir']}/data/speck/companion_html")
       add_item("AUGUSTUS_SCORE_THRESHOLD", job[:augustus_score_threshold].round(2))
       add_item("TAXON_ID", job[:taxon_id])

--- a/app/views/jobs/_tabs.html.erb
+++ b/app/views/jobs/_tabs.html.erb
@@ -80,10 +80,22 @@ var vtable;
                 <td>Number of coding genes</td>
                 <td class="text-right"><%= @job.genome_stat[:nof_coding_genes]%></td>
             </tr>
+            <% if @job.genome_stat[:nof_pseudogenes] then %>
+            <tr>
+                <td>Number of pseudogenes</td>
+                <td class="text-right"><%= @job.genome_stat[:nof_pseudogenes]%></td>
+            </tr>
+            <% end %>
             <tr>
                 <td>Number of genes with function</td>
                 <td class="text-right"><%= @job.genome_stat[:nof_genes_with_function]%></td>
             </tr>
+            <% if @job.genome_stat[:nof_pseudogenes_with_function] then %>
+            <tr>
+                <td>Number of pseudogenes with function</td>
+                <td class="text-right"><%= @job.genome_stat[:nof_pseudogenes_with_function]%></td>
+            </tr>
+            <% end %>
             <tr>
                 <td>Number of non-coding genes</td>
                 <td class="text-right"><%= @job.genome_stat[:nof_genes].to_i - @job.genome_stat[:nof_coding_genes].to_i %></td>

--- a/app/views/jobs/_tabs.html.erb
+++ b/app/views/jobs/_tabs.html.erb
@@ -234,13 +234,13 @@ var vtable;
         <div class="center-block col-md-4" style="float: none;">
           <form>
             <div class="btn-group" data-toggle="buttons">
-                <label onClick="phylocanvas.setTreeType('rectangular');" class="btn btn-default">
+                <label onClick="phylocanvas.setTreeType('rectangular');" class="btn btn-default active">
                     <input id="tree-rectangular" name="treetype" type="radio" checked="checked" /> Rectangular
                 </label>
                 <label onClick="phylocanvas.setTreeType('circular');" class="btn btn-default">
                     <input id="tree-circular" name="treetype" type="radio" /> Circular
                 </label>
-                <label onClick="phylocanvas.setTreeType('radial');" class="btn btn-default active">
+                <label onClick="phylocanvas.setTreeType('radial');" class="btn btn-default">
                     <input id="tree-radial" name="treetype" type="radio" /> Radial
                 </label>
                 <label onClick="phylocanvas.setTreeType('diagonal');" class="btn btn-default">

--- a/db/migrate/20160704145916_add_pseudogenes_to_genome_stats.rb
+++ b/db/migrate/20160704145916_add_pseudogenes_to_genome_stats.rb
@@ -1,0 +1,6 @@
+class AddPseudogenesToGenomeStats < ActiveRecord::Migration
+  def change
+    add_column :genome_stats, :nof_pseudogenes, :integer
+    add_column :genome_stats, :nof_pseudogenes_with_function, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160128103447) do
+ActiveRecord::Schema.define(version: 20160704145916) do
 
   create_table "circos_images", force: :cascade do |t|
     t.string   "file_uid"
@@ -97,9 +97,11 @@ ActiveRecord::Schema.define(version: 20160128103447) do
     t.integer  "nof_coding_genes"
     t.integer  "nof_genes_with_mult_cds"
     t.integer  "nof_genes_with_function"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.integer  "job_id"
+    t.integer  "nof_pseudogenes"
+    t.integer  "nof_pseudogenes_with_function"
   end
 
   add_index "genome_stats", ["job_id"], name: "index_genome_stats_on_job_id"


### PR DESCRIPTION
This PR introduces the following changes:
 - reflect the decision to show the rectangular tree by default in the UI elements -- the rectangular button needs to be selected by default
 - set the `alphanumeric_ids` and  `truncate_input_headers` default config options to sensible values
 - support the pseudogene stats fields present in more recent Companion versions