### PR TITLE
add script to clean up old jobs

### DIFF
--- a/lib/tasks/expire_old.rake
+++ b/lib/tasks/expire_old.rake
@@ -1,0 +1,21 @@
+desc 'expire jobs older than 3 months'
+task :expire_old => :environment do |t, args|
+  oldjobs = Job.where("finished_at < :threshold", {:threshold => 3.months.ago})
+  oldjobs.each do |job|
+    if CONFIG['example_job_id'] == job['job_id'] then
+      puts "Job #{job[:job_id]} '#{job[:name]}' is marked as the example, skipping it"
+      next
+    end
+    if job.sequence_file then
+      job.sequence_file.destroy
+    end
+    if job.transcript_file then
+      job.transcript_file.destroy
+    end
+    if File.exist?("#{job.job_directory}") then
+      FileUtils.rm_rf("#{job.job_directory}")
+    end
+    job.destroy
+    puts "Job #{job[:job_id]} '#{job[:name]}' was deleted."
+  end
+end


### PR DESCRIPTION
Deleting old jobs manually can be tedious and monotone if there are lots, in particular the first time this is needed. This PR introduces a rake task that automates the process by deleting all jobs that finished more than three months before the task is run. If the designated example job is among the candidates, it is obviously spared. 
Use something like:
```
bundle exec rake expire_old
```
to run it.